### PR TITLE
절대경로 삭제 및 키파일 이름만 남김

### DIFF
--- a/PinoConfig.ini
+++ b/PinoConfig.ini
@@ -1,5 +1,5 @@
 [GCloud]
-google_key = /home/pi/Desktop/PinoBot/keys/pinobot01_example.json
+google_key = pinobot01_example.json
 google_project = squarebot01-yauqxo
 language = ko
 time_out = 7


### PR DESCRIPTION
## 💁 설명

코드 내에서 이제 상위경로를 인식하게 되었음으로, 
ini파일에 더이상 상위경로를 포함하면 실행이 불가능한 버그발생.
수정

## 📑 체크리스트

- 1. pino_init 모듈 실행되는 과정에서 다이얼로그플로우 키 로딩되는지 확인, 


## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

- 주의 사항 1
- 주의 사항 2

Close #5